### PR TITLE
Add API key file support, permission warning, and default to sonnet-5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,13 @@ This is a zsh plugin that provides AI-powered command generation and error fixin
 
 ## Architecture
 
-The codebase consists of a single main file:
+The plugin logic is duplicated across three parallel implementations. **When changing behavior, update all three** (they do not share code):
 
-- `main.zsh`: Contains all plugin functionality including system detection, API communication, and command generation
+- `zsh-ai-assist.plugin.zsh`: The canonical zsh plugin — this is what Homebrew, the AUR PKGBUILD, and zsh plugin managers actually install and source.
+- `functions/ask_claude.fish` (with `conf.d/zsh_ai_assist.fish`): The fish shell port.
+- `main.zsh`: A standalone/reference copy of the zsh logic; not sourced by the installed plugin.
+
+Each contains the full plugin functionality including system detection, API communication, and command generation.
 
 Key architectural components:
 
@@ -41,7 +45,8 @@ Since this is a zsh plugin with no build process, testing is done by:
 The plugin requires:
 
 - `CLAUDE_API_KEY`: Anthropic API key (must start with "sk-ant-")
-- `CLAUDE_MODEL`: Optional, defaults to "claude-sonnet-4-20250514"
+- `CLAUDE_API_KEY_FILE`: Optional, path to a file containing the API key; used only when `CLAUDE_API_KEY` is unset. If it too is unset, the key is read from the default `${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key`
+- `CLAUDE_MODEL`: Optional, defaults to "claude-sonnet-5"
 - System dependencies: `curl` and `jq`
 
 ## Key Implementation Details
@@ -51,3 +56,4 @@ The plugin requires:
 - The `??` function analyzes command history to avoid fixing itself recursively
 - All commands are OS-specific with appropriate examples and validation
 - Temperature is set to 0.2 for consistent, deterministic command suggestions
+- When the API key is loaded from a file, its permissions are checked via zsh's `zstat`; a warning is printed (but not fatal) if it is group/other-accessible. Note octal masks in zsh math must use `8#NN` notation since `OCTAL_ZEROES` is off by default

--- a/PKGBUILD-example
+++ b/PKGBUILD-example
@@ -2,7 +2,7 @@
 # Maintainer: Your Name <your.email@example.com>
 
 pkgname=zsh-ai-assist
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="AI-powered command generation and error fixing using Claude AI"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -50,15 +50,26 @@ First, set up your API key:
 
 ```bash
 export CLAUDE_API_KEY="YOUR-API-KEY" # Replace with your actual API key. It should start with "sk-ant-"
-export CLAUDE_MODEL="claude-sonnet-4-20250514"  # Optional, this is the default
+# Alternatively, keep the key out of your environment by saving it to a file. If
+# CLAUDE_API_KEY is unset, the key is read from CLAUDE_API_KEY_FILE, or from the
+# default ${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key if that is unset.
+# export CLAUDE_API_KEY_FILE="/path/to/your/key"  # optional, overrides the default location
+export CLAUDE_MODEL="claude-sonnet-5"  # Optional, this is the default
 ```
 
 **For fish**, add to your fish config:
 
 ```fish
 set -gx CLAUDE_API_KEY "YOUR-API-KEY" # Replace with your actual API key. It should start with "sk-ant-"
-set -gx CLAUDE_MODEL "claude-sonnet-4-20250514"  # Optional, this is the default
+# Alternatively, keep the key out of your environment by saving it to a file. If
+# CLAUDE_API_KEY is unset, the key is read from CLAUDE_API_KEY_FILE, or from the
+# default ~/.config/zsh-ai-assist/api-key (honors XDG_CONFIG_HOME) if that is unset.
+# set -gx CLAUDE_API_KEY_FILE "/path/to/your/key"  # optional, overrides the default location
+set -gx CLAUDE_MODEL "claude-sonnet-5"  # Optional, this is the default
 ```
+
+> **Security note:** When using a key file, restrict it to your user with `chmod 600 <file>`.
+> The plugin prints a warning if the file is readable by group or others.
 
 ### Zsh Package Managers
 

--- a/fisher.yml
+++ b/fisher.yml
@@ -2,5 +2,5 @@ name: zsh-ai-assist
 description: AI-powered command generation and error fixing using Claude AI
 author: MKSG-MugunthKumar
 homepage: https://github.com/MKSG-MugunthKumar/zsh-ai-assist
-version: 1.0.0
+version: 1.1.0
 shell: fish

--- a/functions/ask_claude.fish
+++ b/functions/ask_claude.fish
@@ -57,14 +57,51 @@ function ask_claude -d "Generate commands using Claude AI"
         return 1
     end
 
+    # Fall back to reading the API key from a file if the env variable is not set.
+    # Precedence: CLAUDE_API_KEY -> CLAUDE_API_KEY_FILE -> XDG config default.
+    if test -z "$CLAUDE_API_KEY"
+        set -l key_file $CLAUDE_API_KEY_FILE
+        if test -z "$key_file"
+            if set -q XDG_CONFIG_HOME
+                set key_file "$XDG_CONFIG_HOME/zsh-ai-assist/api-key"
+            else
+                set key_file "$HOME/.config/zsh-ai-assist/api-key"
+            end
+        end
+        # -s tests that the file both exists and is non-empty; otherwise
+        # CLAUDE_API_KEY stays unset and the check below shows the error message.
+        if test -s "$key_file"
+            # Warn (but don't fail) if the key file is readable by group/others.
+            # stat flags differ between Linux (-c '%a') and macOS (-f '%Lp').
+            set -l perms (stat -c '%a' "$key_file" 2>/dev/null)
+            if test -z "$perms"
+                set perms (stat -f '%Lp' "$key_file" 2>/dev/null)
+            end
+            if test -n "$perms"; and not string match -q '*00' -- "$perms"
+                set_color yellow
+                echo "Warning: $key_file is readable by other users." >&2
+                echo "Restrict it with: chmod 600 $key_file" >&2
+                set_color normal
+            end
+            set -gx CLAUDE_API_KEY (cat "$key_file" | string replace -ra '\s' '')
+        end
+    end
+
     # Check API key
-    if not set -q CLAUDE_API_KEY
+    if test -z "$CLAUDE_API_KEY"
         set_color red
         echo "Error: CLAUDE_API_KEY is not set."
         set_color normal
         echo "Add this to your fish config:"
         set_color green
         echo "set -gx CLAUDE_API_KEY \"your-api-key\""
+        set_color normal
+        echo "Or save the key to a file (either location works):"
+        set_color green
+        set -l cfg_dir $XDG_CONFIG_HOME
+        test -z "$cfg_dir"; and set cfg_dir "$HOME/.config"
+        echo "  $cfg_dir/zsh-ai-assist/api-key"
+        echo "  set -gx CLAUDE_API_KEY_FILE \"/path/to/your/key\"  # custom location"
         set_color normal
         return 1
     end
@@ -80,7 +117,7 @@ function ask_claude -d "Generate commands using Claude AI"
 
     # Set default model if not set
     if not set -q CLAUDE_MODEL
-        set -gx CLAUDE_MODEL "claude-sonnet-4-5-20250929"
+        set -gx CLAUDE_MODEL "claude-sonnet-5"
     end
 
     # Join all arguments as the user prompt

--- a/homebrew-formula-example.rb
+++ b/homebrew-formula-example.rb
@@ -4,7 +4,7 @@
 class ZshAiAssist < Formula
   desc "AI-powered command generation and error fixing using Claude AI"
   homepage "https://github.com/MKSG-MugunthKumar/zsh-ai-assist"
-  url "https://github.com/MKSG-MugunthKumar/zsh-ai-assist/archive/refs/tags/v1.0.0.tar.gz"
+  url "https://github.com/MKSG-MugunthKumar/zsh-ai-assist/archive/refs/tags/v1.1.0.tar.gz"
   sha256 "REPLACE_WITH_ACTUAL_SHA256"
   license "MIT"
 

--- a/main.zsh
+++ b/main.zsh
@@ -52,11 +52,39 @@ function ask-claude() {
         return 1
     fi
 
+    # Fall back to reading the API key from a file if the env variable is not set.
+    # Precedence: CLAUDE_API_KEY -> CLAUDE_API_KEY_FILE -> XDG config default.
+    if [[ -z "$CLAUDE_API_KEY" ]]; then
+        local key_file="${CLAUDE_API_KEY_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key}"
+        # -s tests that the file both exists and is non-empty; otherwise CLAUDE_API_KEY
+        # stays unset and the check below shows the standard error message.
+        if [[ -s "$key_file" ]]; then
+            # Warn (but don't fail) if the key file is readable by group/others.
+            # Uses zsh's stat module so it works the same on macOS and Linux.
+            zmodload -F zsh/stat b:zstat 2>/dev/null
+            if (( $+builtins[zstat] )); then
+                local -a key_stat
+                zstat -A key_stat +mode "$key_file" 2>/dev/null
+                # 8#77 = octal 077; zsh math treats a bare leading 0 as decimal
+                # unless OCTAL_ZEROES is set, so use explicit base notation.
+                if (( ${#key_stat} && (key_stat[1] & 8#77) )); then
+                    echo -e "\033[33mWarning: $key_file is readable by other users.\033[0m" >&2
+                    echo -e "\033[33mRestrict it with: chmod 600 $key_file\033[0m" >&2
+                fi
+            fi
+            CLAUDE_API_KEY="$(<"$key_file")"
+            CLAUDE_API_KEY="${CLAUDE_API_KEY//[[:space:]]/}"  # strip any surrounding whitespace/newlines
+        fi
+    fi
+
     # Check API key
     if [[ -z "$CLAUDE_API_KEY" ]]; then
         echo -e "\033[31mError: CLAUDE_API_KEY is not set.\033[0m"
         echo "Add this to your ~/.zshrc file:"
         echo -e "\033[32mexport CLAUDE_API_KEY=\"your-api-key\"\033[0m"
+        echo "Or save the key to a file (either location works):"
+        echo -e "\033[32m  ${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key\033[0m"
+        echo -e "\033[32m  export CLAUDE_API_KEY_FILE=\"/path/to/your/key\"  # custom location\033[0m"
         return 1
     fi
 
@@ -69,7 +97,7 @@ function ask-claude() {
 
     # Set default model if not set
     if [[ -z "$CLAUDE_MODEL" ]]; then
-        export CLAUDE_MODEL="claude-sonnet-4-20250514"
+        export CLAUDE_MODEL="claude-sonnet-5"
     fi
 
     # Concatenate all arguments as the user prompt

--- a/zsh-ai-assist.plugin.zsh
+++ b/zsh-ai-assist.plugin.zsh
@@ -57,11 +57,39 @@ function ask-claude() {
         return 1
     fi
 
+    # Fall back to reading the API key from a file if the env variable is not set.
+    # Precedence: CLAUDE_API_KEY -> CLAUDE_API_KEY_FILE -> XDG config default.
+    if [[ -z "$CLAUDE_API_KEY" ]]; then
+        local key_file="${CLAUDE_API_KEY_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key}"
+        # -s tests that the file both exists and is non-empty; otherwise CLAUDE_API_KEY
+        # stays unset and the check below shows the standard error message.
+        if [[ -s "$key_file" ]]; then
+            # Warn (but don't fail) if the key file is readable by group/others.
+            # Uses zsh's stat module so it works the same on macOS and Linux.
+            zmodload -F zsh/stat b:zstat 2>/dev/null
+            if (( $+builtins[zstat] )); then
+                local -a key_stat
+                zstat -A key_stat +mode "$key_file" 2>/dev/null
+                # 8#77 = octal 077; zsh math treats a bare leading 0 as decimal
+                # unless OCTAL_ZEROES is set, so use explicit base notation.
+                if (( ${#key_stat} && (key_stat[1] & 8#77) )); then
+                    echo -e "\033[33mWarning: $key_file is readable by other users.\033[0m" >&2
+                    echo -e "\033[33mRestrict it with: chmod 600 $key_file\033[0m" >&2
+                fi
+            fi
+            CLAUDE_API_KEY="$(<"$key_file")"
+            CLAUDE_API_KEY="${CLAUDE_API_KEY//[[:space:]]/}"  # strip any surrounding whitespace/newlines
+        fi
+    fi
+
     # Check API key
     if [[ -z "$CLAUDE_API_KEY" ]]; then
         echo -e "\033[31mError: CLAUDE_API_KEY is not set.\033[0m"
         echo "Add this to your ~/.zshrc file:"
         echo -e "\033[32mexport CLAUDE_API_KEY=\"your-api-key\"\033[0m"
+        echo "Or save the key to a file (either location works):"
+        echo -e "\033[32m  ${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key\033[0m"
+        echo -e "\033[32m  export CLAUDE_API_KEY_FILE=\"/path/to/your/key\"  # custom location\033[0m"
         return 1
     fi
 
@@ -74,7 +102,7 @@ function ask-claude() {
 
     # Set default model if not set
     if [[ -z "$CLAUDE_MODEL" ]]; then
-        export CLAUDE_MODEL="claude-sonnet-4-20250514"
+        export CLAUDE_MODEL="claude-sonnet-5"
     fi
 
     # Concatenate all arguments as the user prompt


### PR DESCRIPTION
## Summary
- Load `CLAUDE_API_KEY` from a file when the env var is unset. Precedence: `CLAUDE_API_KEY` → `CLAUDE_API_KEY_FILE` → XDG default `${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai-assist/api-key`.
- Warn (non-fatal) when the key file is group/other-readable, nudging `chmod 600`.
- Update the default model fallback to `claude-sonnet-5`.

## Scope
Applied across all three implementations (`zsh-ai-assist.plugin.zsh`, `functions/ask_claude.fish`, `main.zsh`), since the logic is currently duplicated rather than shared. Documented that duplication in `CLAUDE.md`. Bumped packaging version `1.0.0` → `1.1.0`.

## Testing
- zsh: verified key-file loading, permission warning (`640`→warn, `600`→silent), and the no-key error path.
- fish: reviewed by reading (fish not installed here); to be validated in a distrobox image.